### PR TITLE
Allow introspection into probe definition from Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ you will need to specify that there are git submodule dependencies:
       args[2])
     }'
 
+### Probes in Ruby
+
+Introspection can be done on a probe from within Ruby using the
+following commands:
+
+```ruby
+probe.function  => :myfn
+probe.name      => :probe
+probe.arguments => [:string, :string, :integer]
+```
+
 ## Additional Resources
 
 - [User-Level-Statically Defined Tracing](http://www.solarisinternals.com/wiki/index.php/DTrace_Topics_USDT#USDT)

--- a/ext/usdt/test.rb
+++ b/ext/usdt/test.rb
@@ -1,12 +1,29 @@
 require File.expand_path(File.dirname(__FILE__)) + '/usdt'
 
+puts "## Provider"
 provider = USDT::Provider.create :ruby, :test
 puts provider
-p = provider.probe(:myfn, :probe,
+
+puts
+puts "## Probe with sym definition"
+probe = provider.probe(:myfn, :probe,
                    :string, :string, :integer)
+puts probe
+puts "probe.function: #{probe.function.inspect}"
+puts "probe.name: #{probe.name.inspect}"
+puts "probe.arguments: #{probe.arguments.inspect}"
+
+puts
+puts "## Probe with string definition"
+probe_str = provider.probe('myfn', 'str', :string)
+puts probe_str
+puts "probe.function: #{probe_str.function.inspect}"
+puts "probe.name: #{probe_str.name.inspect}"
+puts "probe.arguments: #{probe_str.arguments.inspect}"
 
 provider.enable
 
+puts
 puts "run:\nsudo dtrace -n 'ruby*:test:myfn:probe { printf(\"%s %s %d\",
   copyinstr(arg0),
   copyinstr(arg1),
@@ -14,8 +31,8 @@ puts "run:\nsudo dtrace -n 'ruby*:test:myfn:probe { printf(\"%s %s %d\",
 }'"
 
 while true
-  if p.enabled? 
-    p.fire("one", "two", 3)
+  if probe.enabled? 
+    probe.fire("one", "two", 3)
     puts("Fired!")
   end
   sleep 0.5


### PR DESCRIPTION
probe.function => :myfn
probe.name => :probe
probe.arguments => [:string, :integer]

My C is very rusty, so please let me know if you see any issues with this!
