### PR TITLE
Rake tasks to prepare project for release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,16 @@
 require 'bundler/gem_tasks'
+
+namespace :ext do
+  desc 'checkout git submodules'
+  task :checkout do
+    sh('git submodule update --init')
+  end
+
+  desc 'make clean in extensions'
+  task :clean => :checkout do
+    sh('cd ext/libusdt && make clean')
+    sh('cd ext/usdt && make clean')
+  end
+end
+
+task :release => 'ext:clean'


### PR DESCRIPTION
Looks like v0.2.0 was released without the libusdt files, so it's not possible to install the gem from rubygems (errors out trying to find usdt.h).

This is a guess at a solution, to have rake run a few commands to checkout the submodules and clean them before pushing files to rubygems.
